### PR TITLE
Default export of `react-dom/client` not resolved by Vite dev server

### DIFF
--- a/.changeset/breezy-rice-change.md
+++ b/.changeset/breezy-rice-change.md
@@ -1,0 +1,5 @@
+---
+"@phoria/phoria-react": patch
+---
+
+Fixes issue with default export not being resolved from "react-dom/client" by Vite dev server.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # to create release (changesets/action)
+      issues: write         # to post issue comments (changesets/action)
+      pull-requests: write  # to create pull request (changesets/action)
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/phoria-react/package.json
+++ b/packages/phoria-react/package.json
@@ -79,8 +79,8 @@
 	},
 	"peerDependencies": {
 		"@phoria/phoria": "^0.1.0",
-		"@types/react": "npm:types-react@^19.0.0-rc",
-		"@types/react-dom": "npm:types-react-dom@^19.0.0-rc",
+		"@types/react": "npm:types-react@^19.0.0-rc.1",
+		"@types/react-dom": "npm:types-react-dom@^19.0.0-rc.1",
 		"@vitejs/plugin-react": "^4.0.0",
 		"react": "^19.0.0-rc",
 		"react-dom": "^19.0.0-rc",

--- a/packages/phoria-react/src/client/csr.tsx
+++ b/packages/phoria-react/src/client/csr.tsx
@@ -7,7 +7,11 @@ const service: PhoriaIslandComponentCsrService = {
 
 		const mode = options?.mode ?? csrMountMode.hydrate
 
-		Promise.all([import("react"), import("react-dom/client"), islandImport]).then(([React, ReactDOM, Island]) => {
+		Promise.all([
+			import("react").then((m) => m.default),
+			import("react-dom/client").then((m) => m.default),
+			islandImport
+		]).then(([React, ReactDOM, Island]) => {
 			if (mode === csrMountMode.hydrate) {
 				ReactDOM.hydrateRoot(
 					island,


### PR DESCRIPTION
* When using the `@phoria/phoria-react` on the client in dev mode there is an error when hydrating a React component
* `hydrateRoot is not a function`
* `hydrateRoot` should be a function exposed by the default export of `react-dom/client`, which is being lazily imported by the `csr` module
* The Vite dev server is doing some bundling and optimisation before it gets to the client, which results in the imported module's default export not being resolved and `hydrateRoot` being called on the module itself hence the "not found" error
  * Weirdly `react` is also lazily imported, but Vite is injecting some additional code to resolve the default export, but doesn't do the same for `react-dom/client`
* This change explcitly resolves the default export of the lazily imported modules (similar to what Vite is doing for the `react` import)