### PR TITLE
Appsettings supplied to the Phoria Vite plugin are not merged with defaults

### DIFF
--- a/.changeset/moody-tigers-mate.md
+++ b/.changeset/moody-tigers-mate.md
@@ -1,0 +1,5 @@
+---
+"@phoria/phoria": patch
+---
+
+Fixes appsettings supplied directly to the Vite plugin not being merged with defaults

--- a/packages/phoria-islands/src/server/appsettings.ts
+++ b/packages/phoria-islands/src/server/appsettings.ts
@@ -54,6 +54,7 @@ interface PhoriaAppSettingsOptions {
 	encoding: BufferEncoding
 	cwd: string
 	environment?: string
+	inlineSettings?: Partial<PhoriaAppSettings>
 }
 
 const defaultAppsettingsOptions: PhoriaAppSettingsOptions = {
@@ -76,12 +77,14 @@ async function getPhoriaAppSettings(options?: Partial<PhoriaAppSettingsOptions>)
 
 	const appsettings = await parseAppSettings(opts.fileName, opts.cwd, opts.encoding)
 
+	const baseappsettings = defu(appsettings, opts.inlineSettings ?? {})
+
 	const envAppsettings =
 		typeof opts.environment === "string"
 			? await parseAppSettings(getEnvAppsettingsFileName(opts.fileName, opts.environment), opts.cwd, opts.encoding)
 			: {}
 
-	return defu(envAppsettings, appsettings)
+	return defu(envAppsettings, baseappsettings)
 }
 
 // Defaults here must be in sync with the defaults set in `Phoria/PhoriaOptions.cs`

--- a/packages/phoria-islands/src/vite/plugin.ts
+++ b/packages/phoria-islands/src/vite/plugin.ts
@@ -2,22 +2,26 @@ import type { PluginOption, UserConfig } from "vite"
 import { type PhoriaAppSettings, parsePhoriaAppSettings } from "~/server/appsettings"
 
 interface PhoriaPluginOptions {
-	appsettings: PhoriaAppSettings
+	appsettings: Partial<PhoriaAppSettings>
 }
 
-function setRoot(config: UserConfig, appsettings: PhoriaAppSettings) {
+function setRoot(config: UserConfig, appsettings: Partial<PhoriaAppSettings>) {
 	if (typeof config.root === "undefined") {
 		config.root = appsettings.Root
 	}
 }
 
-function setBase(config: UserConfig, appsettings: PhoriaAppSettings) {
+function setBase(config: UserConfig, appsettings: Partial<PhoriaAppSettings>) {
 	if (typeof config.base === "undefined") {
 		config.base = appsettings.Base
 	}
 }
 
-function setBuild(config: UserConfig, appsettings: PhoriaAppSettings) {
+function setBuild(config: UserConfig, appsettings: Partial<PhoriaAppSettings>) {
+	if (typeof appsettings.Entry === "undefined") {
+		return
+	}
+
 	if (typeof config.build === "undefined") {
 		config.build = {
 			rollupOptions: {
@@ -90,9 +94,10 @@ function phoriaPlugin(options?: Partial<PhoriaPluginOptions>): PluginOption {
 		config: async (config) => {
 			const dotnetEnv = process.env.DOTNET_ENVIRONMENT ?? process.env.ASPNETCORE_ENVIRONMENT ?? "development"
 
-			const appsettings = options?.appsettings
-				? options.appsettings
-				: await parsePhoriaAppSettings({ environment: dotnetEnv })
+			const appsettings = await parsePhoriaAppSettings({
+				environment: dotnetEnv,
+				inlineSettings: options?.appsettings
+			})
 
 			setRoot(config, appsettings)
 			setBase(config, appsettings)


### PR DESCRIPTION
* You must supply all appsettings, but the intention is that you can supply partial appsettings, which would merge with the defaults or those set in the appsettings file