### PR TITLE
docs: rewrite getting started guide

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,17 @@
 {
+	"cSpell.words": [
+		"appsettings",
+		"aspnet",
+		"ASPNETCORE",
+		"Blazor",
+		"cmeeg",
+		"FOUC",
+		"giget",
+		"listhen",
+		"Phoria",
+		"Tinylibs",
+		"unjs"
+	],
 	"dotnet.defaultSolution": "Phoria.sln",
 	"editor.defaultFormatter": "biomejs.biome",
 	"html.format.enable": true,

--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ Phoria allows you to easily and efficiently render [islands of interactivity](ht
 
 The quickest way to get started is to clone an example project using [giget](https://unjs.io/packages/giget):
 
-* React: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-react my-project`
-* Svelte: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-svelte my-project`
-* Vue: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-vue my-project`
+* React: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-react <target_dir>`
+* Svelte: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-svelte <target_dir>`
+* Vue: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-vue <target_dir>`
+
+> [!IMPORTANT]
+> You will need to replace:
+> * `<target_dir>` with the name of the local directory you want to clone the example project to
 
 Or feel free to choose any one of the [other examples available](https://github.com/CMeeg/phoria-examples/tree/main/examples).
 
@@ -31,25 +35,29 @@ Or feel free to choose any one of the [other examples available](https://github.
 
 ## Usage
 
-> [!NOTE]
-> The Usage documentation is a work in progress. If there is something missing that needs clarification while it is being worked on, or if you have an idea or request for documentation not mentioned below, please raise an issue.
-
-* Phoria Islands
-  * Supported UI frameworks
-  * Component register
-* Phoria Server
-  * Client Entry
-  * Server Entry
-* Phoria Web App
-* Configuration
+* [Getting started](./docs/guides/getting-started.md)
 * [Building for production](./docs/guides/building-for-production.md)
-* Deployment
+* [Deployment](./docs/guides/deployment.md)
+
+> [!NOTE]
+> The Usage documentation is a work in progress and will be expanded on in time. If there is something missing that needs clarification while it is being worked on, or if you have an idea or request for documentation not mentioned below, please raise an issue.
+
+## About Phoria
+
+The idea for this project came about after using [Astro](https://astro.build/) and enjoying the whole experience with their implementation of [Islands architecture](https://docs.astro.build/en/concepts/islands/). I began to wonder what it would be like to have a similar experience in dotnet where the back-end is driven by dotnet Razor Pages or MVC, but you could easily add islands of interactivity using modern UI framework components.
+
+Looking at the existing dotnet ecosystem:
+
+* Blazor allows for a component-driven UI architecture, but it requires buying into a completely different and much less mature ecosystem than those offered, and already embraced by, the wider UI development community
+* Microsoft seem to have settled on recommending a BFF (Backend For Frontend) pattern for integrating dotnet with UI frameworks such as React, Vue etc - this is certainly a valid approach, but isn't always a good fit if you would prefer or have to use dotnet at the application layer instead of "just" to deliver APIs
+
+Phoria's aim is to allow you to build a dotnet web application using the tools and libraries you are already familiar with on the back-end, but with the added benefit of being able to easily and efficiently render islands of interactivity using the UI frameworks and libraries you are familiar with on the front-end.
 
 ## Acknowledgements
 
 ### Inspiration
 
-The idea for this project came about after using [Astro](https://astro.build/) and thoroughly enjoying the whole experience with their implementation of the [Islands architecture](https://docs.astro.build/en/concepts/islands/). Astro was the catalyst and continues to inspire to this day.
+[Astro](https://astro.build/) is the primary inspiration for this project in both its conception and implementation.
 
 The approach that the Remix team took to their [Vite plugin](https://remix.run/docs/en/main/guides/vite) and how they structure their applications is also a big inspiration.
 
@@ -62,6 +70,12 @@ This project would have been significantly slower to get off the ground if it wa
 * [Vite.AspNetCore](https://github.com/Eptagone/Vite.AspNetCore); and
 * [NodeReact.NET](https://github.com/DaniilSokolyuk/NodeReact.NET)
 
-The initial idea was to just consume and use these libraries in Phoria, but the scope for Phoria quickly diverged and would have required submitting changes upstream that seemed at odds with the scope of these libraries.
+The initial idea was to just consume and use these libraries in Phoria, but the scope for Phoria quickly diverged and would have required submitting changes upstream that seemed at odds with the scope of these libraries. For example, `Vite.AspNetCore` is focused on client-side rendering and `NodeReact.NET` is focused (unsurprisingly) on React and uses Webpack.
 
-Parts of their codebases are used in the dotnet Phoria library and helped form a basis from which to build out some of the features that Phoria provides.
+Parts of their codebases are used in the dotnet Phoria library (with license attribution) and helped form a basis from which to build out some of the features that Phoria provides. So a massive thank you to the maintainers of these libraries!
+
+Phoria also wouldn't be possible without:
+
+* [Vite](https://vite.dev/) and its amazing ecosystem of plugins and tools
+* [h3](https://h3.unjs.io/) and the [unjs](https://unjs.io/) ecosystem
+* The [Tinylibs](https://tinylibs.github.io/) libraries

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 Phoria allows you to easily and efficiently render [islands of interactivity](https://docs.astro.build/en/concepts/islands/) using [React](https://react.dev/), [Svelte](https://svelte.dev/) or [Vue](https://vuejs.org/) within your dotnet web app (Razor Pages or MVC) using both Client Side Rendering (CSR) and Server Side Rendering (SSR).
 
-![Screenshot showing a Phoria Island TagHelper being used in a dotnet Razor Pages app to render a React component](./docs/assets/intro.png)
-
 * ⚡ Built around [Vite](https://vite.dev/), which means you can enjoy a first class development experience, lightning fast HMR and access to its expansive plugin catalogue and ecosystem
 * 🏝️ Easily and efficiently render islands using any supported UI framework (or frameworks)
 * 🌊 Client Side Rendering and support for multiple client hydration strategies via client directives such as on load, on idle, on visible and on match media query
 * 🔋 Server Side Rendering of Islands within your dotnet web app (Razor Pages or MVC) views
 * 📦 Easily pass props from your dotnet web app to your Islands
 * ⚙️ Shared configuration between dotnet and Vite using standard dotnet `appsettings.json` files and `dotnet dev-certs`
+
+![Screenshot showing a Phoria Island TagHelper being used in a dotnet Razor Pages app to render a React component](./docs/assets/intro.png)
 
 ## Getting started
 
@@ -26,15 +26,13 @@ The quickest way to get started is to clone an example project using [giget](htt
 
 Or feel free to choose any one of the [other examples available](https://github.com/CMeeg/phoria-examples/tree/main/examples).
 
-Alternatively you can [add Phoria to an existing dotnet project](./docs/guides/getting-started.md#manually-add-phoria-to-an-existing-dotnet-project).
-
 > [!IMPORTANT]
-> Please see the [getting started](./docs/guides/getting-started.md) guide for a complete guide to getting up and running with Phoria.
+> Please see the [Getting started](./docs/guides/getting-started.md) guide for a complete guide to getting up and running with Phoria including how to [add Phoria to an existing dotnet project](./docs/guides/getting-started.md#manually-add-phoria-to-an-existing-dotnet-project).
 
 ## Usage
 
 > [!NOTE]
-> The usage documentation is a work in progress. If there is something missing that needs clarification or if you have an idea or request for documentation not mentioned below, please raise an issue.
+> The Usage documentation is a work in progress. If there is something missing that needs clarification while it is being worked on, or if you have an idea or request for documentation not mentioned below, please raise an issue.
 
 * Phoria Islands
   * Supported UI frameworks
@@ -66,4 +64,4 @@ This project would have been significantly slower to get off the ground if it wa
 
 The initial idea was to just consume and use these libraries in Phoria, but the scope for Phoria quickly diverged and would have required submitting changes upstream that seemed at odds with the scope of these libraries.
 
-Parts of their codebases are used in the dotnet Phoria library and helped form a basis from which to build out the features that Phoria provides.
+Parts of their codebases are used in the dotnet Phoria library and helped form a basis from which to build out some of the features that Phoria provides.

--- a/README.md
+++ b/README.md
@@ -1,40 +1,51 @@
 <div align="center">
-  <p><img width="120" height="133" src="/docs/assets/phoria.svg" alt="Phoria logo"></p>
+  <p><img width="120" height="133" src="./docs/assets/phoria.svg" alt="Phoria logo"></p>
   <h1>phoria<br><br></h1>
   <p>🏝️ <i>Islands architecture for dotnet powered by Vite</i> ⚡</p>
   <p><hr></p>
 </div>
 
-Phoria allows you to easily and efficiently render [islands of interactivity](https://docs.astro.build/en/concepts/islands/) using [React](https://react.dev/), [Svelte](https://svelte.dev/) or [Vue](https://vuejs.org/) within your dotnet web app (Razor Pages or MVC) using both Client Side Rendering and Server Side Rendering.
+Phoria allows you to easily and efficiently render [islands of interactivity](https://docs.astro.build/en/concepts/islands/) using [React](https://react.dev/), [Svelte](https://svelte.dev/) or [Vue](https://vuejs.org/) within your dotnet web app (Razor Pages or MVC) using both Client Side Rendering (CSR) and Server Side Rendering (SSR).
+
+![Screenshot showing a Phoria Island TagHelper being used in a dotnet Razor Pages app to render a React component](./docs/assets/intro.png)
 
 * ⚡ Built around [Vite](https://vite.dev/), which means you can enjoy a first class development experience, lightning fast HMR and access to its expansive plugin catalogue and ecosystem
-* 🏝️ Easily and efficiently render islands using any supported UI framework(s)
-* 🌊 Client Side Rendering (CSR) and support for multiple client hydration strategies via client directives such as on load, on idle, on visible and on match media query
-* 🔋 Server Side Rendering (SSR) of Islands within your dotnet web app (Razor Pages or MVC) views
-* 📦 Easily pass props from your dotnet web app to your UI components
-* ⚙️ Shared configuration between dotnet and Vite using `appsettings.json` files and `dotnet dev-certs` (via an optional plugin)
-
-![Screenshot showing a Phoria Island TagHelper being used in a dotnet Razor Pages app to render a React component](/docs/assets/intro.png)
+* 🏝️ Easily and efficiently render islands using any supported UI framework (or frameworks)
+* 🌊 Client Side Rendering and support for multiple client hydration strategies via client directives such as on load, on idle, on visible and on match media query
+* 🔋 Server Side Rendering of Islands within your dotnet web app (Razor Pages or MVC) views
+* 📦 Easily pass props from your dotnet web app to your Islands
+* ⚙️ Shared configuration between dotnet and Vite using standard dotnet `appsettings.json` files and `dotnet dev-certs`
 
 ## Getting started
 
-Please see the [getting started](./docs/guides/getting-started.md) guide.
+The quickest way to get started is to clone an example project using [giget](https://unjs.io/packages/giget):
+
+* React: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-react my-project`
+* Svelte: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-svelte my-project`
+* Vue: `npx giget@latest gh:cmeeg/phoria-examples/examples/framework-vue my-project`
+
+Or feel free to choose any one of the [other examples available](https://github.com/CMeeg/phoria-examples/tree/main/examples).
+
+Alternatively you can [add Phoria to an existing dotnet project](./docs/guides/getting-started.md#manually-add-phoria-to-an-existing-dotnet-project).
+
+> [!IMPORTANT]
+> Please see the [getting started](./docs/guides/getting-started.md) guide for a complete guide to getting up and running with Phoria.
 
 ## Usage
 
 > [!NOTE]
-> This documentation is a work in progress. If there is something missing that needs clarification or if you have an idea or request for documentation not mentioned below, please raise an issue.
+> The usage documentation is a work in progress. If there is something missing that needs clarification or if you have an idea or request for documentation not mentioned below, please raise an issue.
 
-* [Phoria Islands](./docs/guides/phoria-islands.md)
-  * [Supported UI frameworks](./docs/guides/supported-ui-frameworks.md)
-  * [Component register](./docs/guides/component-register.md)
-* [Phoria Server](./docs/guides/phoria-server.md)
-  * [Client Entry](./docs/guides/client-entry.md)
-  * [Server Entry](./docs/guides/server-entry.md)
-* [Phoria Web App](./docs/guides/phoria-web-app.md)
-* [Configuration](./docs/guides/configuration.md)
+* Phoria Islands
+  * Supported UI frameworks
+  * Component register
+* Phoria Server
+  * Client Entry
+  * Server Entry
+* Phoria Web App
+* Configuration
 * [Building for production](./docs/guides/building-for-production.md)
-* [Deployment](./docs/guides/deployment.md)
+* Deployment
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p><img width="120" height="133" src="./docs/assets/phoria.svg" alt="Phoria logo"></p>
-  <h1>phoria<br><br></h1>
+  <h1>Phoria<br><br></h1>
   <p>🏝️ <i>Islands architecture for dotnet powered by Vite</i> ⚡</p>
   <p><hr></p>
 </div>
@@ -30,7 +30,7 @@ The quickest way to get started is to clone an example project using [giget](htt
 
 Or feel free to choose any one of the [other examples available](https://github.com/CMeeg/phoria-examples/tree/main/examples).
 
-> [!IMPORTANT]
+> [!TIP]
 > Please see the [Getting started](./docs/guides/getting-started.md) guide for a complete guide to getting up and running with Phoria including how to [add Phoria to an existing dotnet project](./docs/guides/getting-started.md#manually-add-phoria-to-an-existing-dotnet-project).
 
 ## Usage

--- a/docs/guides/building-for-production.md
+++ b/docs/guides/building-for-production.md
@@ -1,16 +1,19 @@
 # Building for production
 
-There are three parts to a Phoria solution that need to be built for production:
+This guide will walk you through adding `scripts` to `package.json` that will [build](#build-scripts) the three parts of a Phoria solution that are required when running in production:
 
 * Phoria Islands
 * Phoria Web App
 * Phoria Server
 
-We are going to setup `scripts` in `package.json` to [build](#build-scripts) all of these parts, and then add some other `scripts` that we can use to [preview](#preview-scripts) a production build in the local environment.
+Also included in this guide are instructions for adding [preview](#preview-scripts) `scripts` so that you can run the production build in the local environment for testing purposes.
+
+> [!TIP]
+> If you cloned an example project to get started you should already have `build` and `preview` scripts included in your `package.json`. This guide is for those who want to add these scripts manually to their solution, or for those who want to understand more about what the scripts do.
 
 ## Build scripts
 
-These are the `scripts` we will add to build our Phoria solution:
+These are the `scripts` that you will need to add to build your Phoria solution for production:
 
 ```json
 {
@@ -23,31 +26,45 @@ These are the `scripts` we will add to build our Phoria solution:
 }
 ```
 
-Read on if you would like more info about each of the scripts, or you can feel free to skip to the [preview](#preview-scripts) scripts.
+The next sections of the guide will describe each script in turn and any dependencies that you will need to add to your project to support them.
+
+When you have added the scripts and all required dependencies you can build your Phoria solution for production by running:
+
+```shell
+pnpm run build
+```
 
 ### `build`
 
-We are using the [`npm-run-all`](https://github.com/mysticatea/npm-run-all) package to run the other three build scripts in parallel.
+This script is a convenience script that uses the [`npm-run-all`](https://github.com/mysticatea/npm-run-all) package to run the other three build scripts in parallel.
+
+```shell
+pnpm add -D npm-run-all
+```
 
 > [!NOTE]
-> `npm-run-all` is not required and you can use some other package or tool or shell feature (e.g. `&`) to do the same thing. The reason we are using it is because `&` doesn't work consistently on Windows.
+> `npm-run-all` is not required and you can use some other package or tool or shell feature (e.g. `&`) to do the same thing, if you prefer. The reason it is used here is because `&` doesn't work consistently on Windows and we want our scripts to be platform-agnostic.
 
 ### `build:islands`
 
-This script uses Vite to build the optimised CSR and SSR bundles that will be used in production and produces a [manifest](https://main.vite.dev/config/build-options.html#build-manifest):
+This script uses [Vite's Environment API](https://vite.dev/guide/api-environment.html) to build the optimised CSR and SSR bundles that will be used in production and it also produces a [manifest](https://main.vite.dev/config/build-options.html#build-manifest) for Phoria to use:
 
 * The CSR bundles are used by Phoria Islands to load component assets on the client
 * The SSR bundles are used by the Phoria Server to load component assets on the server
 * The manifest is used by the Phoria Web App to [generate preload directives](https://main.vite.dev/guide/ssr#generating-preload-directives)
 
-The build configuration for Vite is provided via your Vite config file (e.g. `vite.config.ts`), and the configuration for Phoria specifically is provided via the `phoria*` plugins.
+The build configuration for Vite is provided via your Vite config file (e.g. `vite.config.ts`), and the configuration for Phoria specifically is provided via the `phoria*` Vite plugins.
+
+By default, the build output will be placed in the `<Vite root>/dist` directory.
 
 ### `build:webapp`
 
 This script uses the [dotnet CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build) to build the Phoria Web App in its `Release` configuration.
 
+By default, the build output will be placed in the `<WebApp root>/bin/Release/<Target framework>` directory.
+
 > [!WARNING]
-> You may need to adjust this command depending on the structure of your project to point to a specific solution (`.sln`) or project (`.csproj`) file.
+> You may need to [adjust this command](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build#arguments) depending on the structure of your project to point to a specific solution (`.sln`) or project (`.csproj`) file.
 
 ### `build:server`
 
@@ -56,14 +73,17 @@ This script uses Vite to build the Phoria Server. It uses a different Vite confi
 Below is an example of a `vite.server.config.ts` that you can use:
 
 ```ts
+import { join } from "node:path"
 import { parsePhoriaAppSettings } from "@phoria/phoria/server"
 import { type UserConfig, defineConfig } from "vite"
 
 export default defineConfig(async () => {
   const dotnetEnv = process.env.DOTNET_ENVIRONMENT ?? process.env.ASPNETCORE_ENVIRONMENT ?? "Development"
-  const appsettings = await parsePhoriaAppSettings({ environment: dotnetEnv })
+  const appsettings = await parsePhoriaAppSettings({
+    environment: dotnetEnv,
+    cwd: join(process.cwd(), "WebApp")
+  })
 
-  // https://vite.dev/config/
   return {
     root: appsettings.root,
     base: appsettings.base,
@@ -81,45 +101,89 @@ export default defineConfig(async () => {
 })
 ```
 
+If you use the configuration above, the build output will be placed in the `<Vite root>/dist/server` directory.
+
+> [!TIP]
+> The `parsePhoriaAppSettings` function is provided by the `@phoria/phoria` package and is used to read the `appsettings` file(s) in the `WebApp` project and provide the configuration to Vite. This is useful for sharing configuration between the Phoria Server and the Phoria Web App.
+
 > [!NOTE]
-> You don't need to use Vite to build the Phoria Server. You could use something like [`tsup`](https://github.com/egoist/tsup) or any other TypeScript to JavaScript transpiler or bundler if you prefer. We are using Vite because we are already using it so its convenient.
+> You don't need to use Vite to build the Phoria Server. You could use something like [`tsup`](https://github.com/egoist/tsup) or any other TypeScript to JavaScript transpiler or bundler if you prefer. It is just convenient to use Vite because we are already using it to build our Phoria Islands and means that we don't need to add another dependency.
 >
-> Equally you could decide to just use JavaScript for your Phoria Server and avoid a build step entirely though we don't recommend it.
+> You could also decide to just use JavaScript for your Phoria Server and avoid a build step entirely if that's what you want to do.
 
 ## Preview scripts
 
-These are the scripts we will add to preview the production build of our Phoria solution locally:
+These are the `scripts` that you will need to preview the production build of our Phoria solution locally:
 
 ```json
 {
   "scripts": {
     "preview": "run-p preview:* -c",
-    "preview:webapp": "cross-env DOTNET_ENVIRONMENT=Preview dotnet --project ./WebApp.csproj -c Release --launch-profile Preview",
-    "preview:server": "cross-env NODE_ENV=production DOTNET_ENVIRONMENT=Preview node ./ui/dist/server/server.js"
+    "preview:webapp": "cross-env DOTNET_ENVIRONMENT=Preview dotnet run --project ./WebApp/WebApp.csproj -c Release --launch-profile Preview",
+    "preview:server": "cross-env NODE_ENV=production DOTNET_ENVIRONMENT=Preview node ./WebApp/ui/dist/server/server.js"
   }
 }
 ```
 
-Read on if you would like more info about each of the scripts.
+The next sections of the guide will describe each script in turn and any dependencies that you will need to add to your project to support them.
+
+When you have added the scripts and all required dependencies you can preview your production build by running:
+
+```shell
+# Build the Phoria solution
+pnpm run build
+
+# Preview the Phoria solution
+pnpm run preview
+```
 
 ### `preview`
 
-We are using `npm-run-all` again here, but the same applies as with the `build` script if you want to use something else.
+This script is a convenience script that uses the [`npm-run-all`](https://github.com/mysticatea/npm-run-all) package to run the other three preview scripts in parallel.
 
-We are also using the [`cross-env` package](https://www.npmjs.com/package/cross-env) to set environment variables in a platform-agnostic way, but feel free to skip that if you don't need it.
+> [!NOTE]
+> This guide will assume that you are using `npm-run-all` in your `build` script so there is no need to install it again, but if you did choose to use something else for your `build` script you will need to make the same adjustments here.
 
 ### `preview:webapp`
 
-We are using the [dotnet CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run) to run the Phoria Web App produced by the `build:webapp` script.
+This script uses the [dotnet CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run) to run the Phoria Web App produced by the [`build:webapp`](#buildwebapp) script.
 
-The [`cross-env`](https://github.com/kentcdodds/cross-env) package is used to set the `DOTNET_ENVIRONMENT` so you can use specific configuration or conditional branching in your code etc that targets the `Preview` environment. This script also assumes that you have a launch profile named `Preview`.
+The [`cross-env`](https://github.com/kentcdodds/cross-env) package is used to set the `DOTNET_ENVIRONMENT` so you can use specific configuration or conditional branching in your code etc that targets the `Preview` environment if you wish.
+
+```shell
+pnpm add -D cross-env
+```
+
+> [!NOTE]
+> `cross-env` is used because we want our scripts to be platform-agnostic, but is not required if you do not need to support Windows environments.
+
+This script also uses a launch profile named `Preview`, which you can add to your `launchSettings.json` file:
+
+```json
+{
+  "profiles": {
+    "Preview": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5245",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Preview"
+      }
+    }
+  }
+}
+```
 
 > [!WARNING]
-> You may need to adjust this command depending on the structure of your project to point to the actual `.dll` of your Phoria Web App produced by the `build:webapp` script.
+> You may need to adjust this command depending on the structure of your project to point to the actual location of your Phoria Web App's `.csproj` file.
 
 ### `preview:server`
 
-This script uses `node` to run the Phoria Server produced by the `build:server` script.
+This script uses `node` to run the Phoria Server produced by the [`build:server`](#buildserver) script. `cross-env` is used again to set environment variables used by the script.
+
+> [!NOTE]
+> This guide will assume that you are using `cross-env` in your other `preview` script so there is no need to install it again, but chose not to use it you will need to make the same adjustments here.
 
 > [!WARNING]
-> You may need to adjust this command depending on your configuration to point to the Phoria Server script produced by the `build:server` script.
+> You may need to adjust this command depending on your configuration to point to the location of the Phoria Server output produced by the `build:server` script.

--- a/docs/guides/building-for-production.md
+++ b/docs/guides/building-for-production.md
@@ -16,8 +16,8 @@ These are the `scripts` we will add to build our Phoria solution:
 {
   "scripts": {
     "build": "run-p build:* -c",
-    "build:app": "vite build --app",
-    "build:dotnet": "dotnet build --configuration Release",
+    "build:islands": "vite build --app",
+    "build:webapp": "dotnet build --configuration Release",
     "build:server": "vite build --config vite.server.config.ts"
   }
 }
@@ -32,7 +32,7 @@ We are using the [`npm-run-all`](https://github.com/mysticatea/npm-run-all) pack
 > [!NOTE]
 > `npm-run-all` is not required and you can use some other package or tool or shell feature (e.g. `&`) to do the same thing. The reason we are using it is because `&` doesn't work consistently on Windows.
 
-### `build:app`
+### `build:islands`
 
 This script uses Vite to build the optimised CSR and SSR bundles that will be used in production and produces a [manifest](https://main.vite.dev/config/build-options.html#build-manifest):
 
@@ -42,7 +42,7 @@ This script uses Vite to build the optimised CSR and SSR bundles that will be us
 
 The build configuration for Vite is provided via your Vite config file (e.g. `vite.config.ts`), and the configuration for Phoria specifically is provided via the `phoria*` plugins.
 
-### `build:dotnet`
+### `build:webapp`
 
 This script uses the [dotnet CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-build) to build the Phoria Web App in its `Release` configuration.
 
@@ -94,8 +94,8 @@ These are the scripts we will add to preview the production build of our Phoria 
 {
   "scripts": {
     "preview": "run-p preview:* -c",
-    "preview:dotnet": "cross-env DOTNET_ENVIRONMENT=Preview dotnet run ./WebApp/bin/Release/net9.0/WebApp.dll --launch-profile Preview",
-    "preview:phoria": "cross-env NODE_ENV=production DOTNET_ENVIRONMENT=Preview node ./ui/dist/server/server.js"
+    "preview:webapp": "cross-env DOTNET_ENVIRONMENT=Preview dotnet --project ./WebApp.csproj -c Release --launch-profile Preview",
+    "preview:server": "cross-env NODE_ENV=production DOTNET_ENVIRONMENT=Preview node ./ui/dist/server/server.js"
   }
 }
 ```
@@ -106,17 +106,18 @@ Read on if you would like more info about each of the scripts.
 
 We are using `npm-run-all` again here, but the same applies as with the `build` script if you want to use something else.
 
+We are also using the [`cross-env` package](https://www.npmjs.com/package/cross-env) to set environment variables in a platform-agnostic way, but feel free to skip that if you don't need it.
 
-### `preview:dotnet`
+### `preview:webapp`
 
-We are using the [dotnet CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run) to run the Phoria Web App produced by the `build:dotnet` script.
+We are using the [dotnet CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run) to run the Phoria Web App produced by the `build:webapp` script.
 
 The [`cross-env`](https://github.com/kentcdodds/cross-env) package is used to set the `DOTNET_ENVIRONMENT` so you can use specific configuration or conditional branching in your code etc that targets the `Preview` environment. This script also assumes that you have a launch profile named `Preview`.
 
 > [!WARNING]
-> You may need to adjust this command depending on the structure of your project to point to the actual `.dll` of your Phoria Web App produced by the `build:dotnet` script.
+> You may need to adjust this command depending on the structure of your project to point to the actual `.dll` of your Phoria Web App produced by the `build:webapp` script.
 
-### `preview:phoria`
+### `preview:server`
 
 This script uses `node` to run the Phoria Server produced by the `build:server` script.
 

--- a/docs/guides/building-for-production.md
+++ b/docs/guides/building-for-production.md
@@ -187,3 +187,7 @@ This script uses `node` to run the Phoria Server produced by the [`build:server`
 
 > [!WARNING]
 > You may need to adjust this command depending on your configuration to point to the location of the Phoria Server output produced by the `build:server` script.
+
+## Next steps
+
+If you would now like to try deploying your production build you can check out the [deployment](./deployment.md) guide.

--- a/docs/guides/building-for-production.md
+++ b/docs/guides/building-for-production.md
@@ -148,7 +148,7 @@ This script is a convenience script that uses the [`npm-run-all`](https://github
 
 This script uses the [dotnet CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run) to run the Phoria Web App produced by the [`build:webapp`](#buildwebapp) script.
 
-The [`cross-env`](https://github.com/kentcdodds/cross-env) package is used to set the `DOTNET_ENVIRONMENT` so you can use specific configuration or conditional branching in your code etc that targets the `Preview` environment if you wish.
+The [`cross-env`](https://github.com/kentcdodds/cross-env) package is used to set the `DOTNET_ENVIRONMENT` environment variable so you can use specific configuration or conditional branching in your code etc that targets the `Preview` environment if you wish.
 
 ```shell
 pnpm add -D cross-env
@@ -181,9 +181,6 @@ This script also uses a launch profile named `Preview`, which you can add to you
 ### `preview:server`
 
 This script uses `node` to run the Phoria Server produced by the [`build:server`](#buildserver) script. `cross-env` is used again to set environment variables used by the script.
-
-> [!NOTE]
-> This guide will assume that you are using `cross-env` in your other `preview` script so there is no need to install it again, but chose not to use it you will need to make the same adjustments here.
 
 > [!WARNING]
 > You may need to adjust this command depending on your configuration to point to the location of the Phoria Server output produced by the `build:server` script.

--- a/docs/guides/component-register.md
+++ b/docs/guides/component-register.md
@@ -1,5 +1,4 @@
 # Component Register
 
-TODO
-
-* Registering components with default or named exports
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,7 +1,4 @@
 # Configuration
 
-TODO
-
-* Options
-* Defaults
-* `phoria` Vite plugin
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -168,8 +168,74 @@ docker rm phoriaapp
 
 ### Setup azd
 
-TODO
+Start by running the following command in the root of your repository:
+
+```shell
+azd init
+```
+
+Then you can proceed through the prompts to setup azd:
+
+* You should be asked how you want to initialise your app - choose "Use code in the current directory"
+  * This may not detect the correct services initially so pay attention before you proceed - you can add and remove services using the prompts provided - what we want is to add just the Phoria dotnet Web App
+  * For example, when running `azd init` on the "Getting started" app a "Vite" service was detected in the root, but that had to be removed and the dotnet app under `./WebApp` had to be added instead
+* `azd` should suggest hosting your app in Azure Container Apps - agree to proceed
+* You should then be prompted to enter a new environment name - enter what you would like here
+
+`azd` will then initialise your app by creating and modifying some files in your repository. The ones we care about are:
+
+* The `infra` directory - this contains the Bicep files that describe the Azure resources that will be provisioned
+* The `azure.yaml` file - this contains the deployment configuration for your app
+* The `.gitignore` file - this has been modified to exclude certain files and directories that `azd` generates and uses, but do not need to be under source control
+
+Any other files produced by the initialisation process are not relevant to this guide and you can decide if you want to keep them or not.
+
+> [!TIP]
+> Feel free to take a look through the `infra` directory if you are interested in how the Azure resources are described, but we won't be going into detail about that in this guide. The idea is that `azd` gives you everything that you need to get started quickly and easily, but if you want to dig deeper and customise things further you can absolutely do that. You can also use [Terraform instead of Bicep](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/use-terraform-for-azd) if you prefer.
+>
+> This guide also isn't aiming to be a guide to `azd` itself so please refer to the official documentation if you have more specific questions.
+
+You will need to make some changes to the `azure.yaml` file to use the Dockerfile that you created earlier. Here is an example of what the `azure.yaml` file should look like - the only part you should need to add is the `docker` section for the `web-app` service:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: getting-started
+metadata:
+  template: azd-init@1.11.1
+services:
+  web-app:
+    project: WebApp
+    host: containerapp
+    language: dotnet
+    docker:
+      path: ./Dockerfile
+      context: ../
+```
 
 ### Deploy with azd
 
-TODO
+If this is the first time you have used `azd` or you have not used it in a while you will need to sign in first:
+
+```shell
+azd auth login
+```
+
+Then you can use the following command to provision the Azure resources required and deploy your app to Azure Container Apps:
+
+```shell
+azd up
+```
+
+You will have to follow some prompts to select the Azure subscription and region that you want to provision your resources in, but then the process should be fully automated and you should see the output of the deployment in your terminal.
+
+Once the deployment is complete you should be presented with a URL that you can use to access your Phoria app running in Azure Container Apps.
+
+> [!TIP]
+> If you make a change to your app you can deploy the changes by running `azd up` again - `azd` will detect if any changes have been made to the hosting environment and skip the provisioning step if it is not necessary.
+
+If you don't want to keep the resources that were provisioned you can run the following command to tear them down:
+
+```shell
+azd down --purge
+```

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,8 +1,175 @@
 # Deployment
 
+This guide will describe the steps required to deploy a [production build](./building-for-production.md) of a Phoria solution to [Azure Container Apps](#deploy-to-azure-container-apps) using Docker and the Azure Developer CLI (azd).
+
+> [!TIP]
+> If you cloned an example project to get started you should already have build scripts included in your project. You may also have scripts for deployment included depending on the example project. This guide is for those who want to setup deployment themselves, or for those who want to understand more about how Phoria is deployed.
+
+> [!IMPORTANT]
+> Currently the guide is focused on deploying to Azure Container Apps, but some of the principles should be applicable to other hosting providers (e.g. AWS) and scenarios (e.g. Aspire, Azure App Service) especially those that support Docker or hosting of dotnet apps in general.
+>
+> If you have questions or problems deploying Phoria to other hosting providers or would like to see this documentation expanded to support other platforms or scenarios please raise an issue, or raise a pull request to contribute to this documentation.
+
+## Deploy to Azure Container Apps
+
+[Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/overview) is a serverless platform for running containerised applications and services. It is powered by Kubernetes, but is a fully managed service that is designed to be simple to use and cost-effective.
+
+[azd](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/overview) simplifies provisioning and deploying resources to Azure.
+
+In this guide we are going to:
+
+* [Add a Dockerfile](#add-a-dockerfile) to create a container image for our Phoria app
+* [Setup azd](#setup-azd) to provision a Azure Container Apps environment
+* [Deploy the Docker container image](#deploy-with-azd) to Azure Container Apps using azd
+
+The example used builds upon the sample app created in the [Getting started](./getting-started.md) guide and assumes that you already have functioning [build scripts](./building-for-production.md) for your app.
+
+### Prerequisites
+
+There is some prerequisite software you will need to have installed before we go any further:
+
+* [Docker Desktop](https://docs.docker.com/desktop/)
+* [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd)
+
+### Add a Dockerfile
+
+First thing we will do is add a Dockerfile to describe how to create a container image for our Phoria app. The image will contain the build output of the Phoria Web App, Islands and the Phoria Server.
+
+```dockerfile
+# UI build stage
+FROM node:22-slim AS uibuild
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+WORKDIR /src
+
+## Copy source code
+COPY . .
+
+## Install deps
+RUN corepack enable
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+
+## Set env for build
+ENV NODE_ENV=production
+ENV DOTNET_ENVIRONMENT=Production
+
+## Build Phoria Islands and Server
+RUN pnpm run build:islands
+RUN pnpm run build:server
+
+## Create deployment package
+RUN mkdir -p /app/WebApp/ui \
+  && cp -r /src/WebApp/ui/dist /app/WebApp/ui/dist \
+  && cp -r /src/node_modules /app/node_modules \
+  && cp /src/package.json /app/package.json
+
+# Dotnet build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS dotnetbuild
+WORKDIR /src
+
+## Copy source code
+COPY . .
+
+## Restore all projects
+RUN dotnet restore
+
+## Create deployment package
+RUN dotnet publish ./WebApp/WebApp.csproj -c Release --no-restore -o /app
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
+ENV NODE_ENV=production
+ENV DOTNET_ENVIRONMENT=Production
+WORKDIR /app
+
+## Copy dotnetbuild assets
+COPY --from=dotnetbuild /app .
+
+## Rename the WebApp binary as otherwise it will conflict with the WebApp directory from the uibuild
+RUN mv /app/WebApp /app/WebAppCmd
+
+## Copy uibuild assets
+COPY --from=uibuild /app .
+
+# Install node for Phoria Server
+ENV NODE_VERSION=22.11.0
+RUN apt-get -y update \
+	&& apt-get install -y curl \
+	&& curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION} -o nodesource_setup.sh | bash \
+	&& apt-get install -y --no-install-recommends nodejs \
+	&& apt-get clean
+
+# Run the app
+USER $APP_UID
+EXPOSE 8080
+ENTRYPOINT ["./WebAppCmd"]
+```
+
+We will also add a `.dockerignore` file in our repository root to exclude files and directories that we don't want to include in the container image:
+
+```plaintext
+# directories
+**/bin/
+**/dist/
+!**/wwwroot/lib/**/dist/
+**/node_modules/
+**/obj/
+
+# files
+Dockerfile*
+**/*.DS_Store
+**/*.env
+**/*.md
+**/*.tmp
+**/*.tsbuildinfo
+```
+
+> [!NOTE]
+> If you have seen reference in other guides to the Phoria Server being a "sidecar" to the dotnet web app and are wondering in that case why we are only building a single container image that contains both the dotnet web app and the Phoria Server - the reason is that azd [does not currently support](https://github.com/Azure/azure-dev/issues/3239) sidecar containers.
+>
+> If you are not using azd however, you should be able to split up the above Dockerfile to build two container images, one for the dotnet web app, and one for the Phoria Server.
+
+We can configure the Phoria web app to start and monitor the Phoria Server process by adding the following config to `WebApp/appsettings.Production.json`:
+
+```json
+{
+	"phoria": {
+		"server": {
+			"process": {
+				"command": "node",
+				"arguments": ["WebApp/ui/dist/server/server.js"]
+			}
+		}
+	}
+}
+```
+
+Now we can build and run the container image using Docker from the root of the repo:
+
+```shell
+# Build the container image
+docker build -f ./WebApp/Dockerfile -t phoriaapp:latest .
+
+# Run the container image
+docker run --name phoriaapp -d -p 3001:8080 phoriaapp:latest
+```
+
+The Phoria app running in the Docker container will now be accessible at [http://localhost:3001](http://localhost:3001) to test everything is working as expected.
+
+When you're done testing you can stop and remove the container image:
+
+```shell
+# Stop the container image
+docker stop phoriaapp
+
+# Remove the container image
+docker rm phoriaapp
+```
+
+### Setup azd
+
 TODO
 
-* Docker
-* azd
-* Azure Container apps
-* Azure App service
+### Deploy with azd
+
+TODO

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -3,7 +3,7 @@
 This guide will describe the steps required to deploy a [production build](./building-for-production.md) of a Phoria solution to [Azure Container Apps](#deploy-to-azure-container-apps) using Docker and the Azure Developer CLI (azd).
 
 > [!TIP]
-> If you cloned an example project to get started you should already have build scripts included in your project. You may also have scripts for deployment included depending on the example project. This guide is for those who want to setup deployment themselves, or for those who want to understand more about how Phoria is deployed.
+> If you cloned an example project to get started you should already have build scripts included in your project. You may also have a Dockerfile and/or scripts for deployment included depending on the example project. This guide is for those who want to setup deployment themselves, or for those who want to understand more about how Phoria is deployed.
 
 > [!IMPORTANT]
 > Currently the guide is focused on deploying to Azure Container Apps, but some of the principles should be applicable to other hosting providers (e.g. AWS) and scenarios (e.g. Aspire, Azure App Service) especially those that support Docker or hosting of dotnet apps in general.
@@ -16,24 +16,24 @@ This guide will describe the steps required to deploy a [production build](./bui
 
 [azd](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/overview) simplifies provisioning and deploying resources to Azure.
 
-In this guide we are going to:
+By following this guide you will:
 
-* [Add a Dockerfile](#add-a-dockerfile) to create a container image for our Phoria app
+* [Add a Dockerfile](#add-a-dockerfile) to create a container image for your Phoria app
 * [Setup azd](#setup-azd) to provision a Azure Container Apps environment
 * [Deploy the Docker container image](#deploy-with-azd) to Azure Container Apps using azd
 
-The example used builds upon the sample app created in the [Getting started](./getting-started.md) guide and assumes that you already have functioning [build scripts](./building-for-production.md) for your app.
+The example project used in this guide builds upon the sample app created in the [Getting started](./getting-started.md) guide and assumes that you already have functioning [build scripts](./building-for-production.md) for your app. You may need to adjust some of the paths and commands in this guide to match your project structure.
 
 ### Prerequisites
 
-There is some prerequisite software you will need to have installed before we go any further:
+There is some prerequisite software you will need to have installed before you go any further:
 
 * [Docker Desktop](https://docs.docker.com/desktop/)
 * [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd)
 
 ### Add a Dockerfile
 
-First thing we will do is add a Dockerfile to describe how to create a container image for our Phoria app. The image will contain the build output of the Phoria Web App, Islands and the Phoria Server.
+First thing you will need to do is add a Dockerfile to describe how to create a container image for your Phoria app. The image will contain the build output of the Phoria Web App, Phoria Islands and the Phoria Server.
 
 ```dockerfile
 # UI build stage
@@ -105,7 +105,7 @@ EXPOSE 8080
 ENTRYPOINT ["./WebAppCmd"]
 ```
 
-We will also add a `.dockerignore` file in our repository root to exclude files and directories that we don't want to include in the container image:
+You will also need to add a `.dockerignore` file in your repository root to exclude files and directories that you don't want to include in the container image:
 
 ```plaintext
 # directories
@@ -125,11 +125,11 @@ Dockerfile*
 ```
 
 > [!NOTE]
-> If you have seen reference in other guides to the Phoria Server being a "sidecar" to the dotnet web app and are wondering in that case why we are only building a single container image that contains both the dotnet web app and the Phoria Server - the reason is that azd [does not currently support](https://github.com/Azure/azure-dev/issues/3239) sidecar containers.
+> If you have seen reference in other guides to the Phoria Server being a "sidecar" to the Phoria Web App and are wondering in that case why we are only building a single container image that contains both the Phoria Web App and the Phoria Server - the reason is that azd [does not currently support](https://github.com/Azure/azure-dev/issues/3239) sidecar containers.
 >
 > If you are not using azd however, you should be able to split up the above Dockerfile to build two container images, one for the dotnet web app, and one for the Phoria Server.
 
-We can configure the Phoria web app to start and monitor the Phoria Server process by adding the following config to `WebApp/appsettings.Production.json`:
+You can configure the Phoria Web App to start and monitor the Phoria Server `node` process by adding the following config to `WebApp/appsettings.Production.json`:
 
 ```json
 {
@@ -144,7 +144,7 @@ We can configure the Phoria web app to start and monitor the Phoria Server proce
 }
 ```
 
-Now we can build and run the container image using Docker from the root of the repo:
+Now you can build and run the container image using Docker from the root of your repo:
 
 ```shell
 # Build the container image
@@ -153,6 +153,9 @@ docker build -f ./WebApp/Dockerfile -t phoriaapp:latest .
 # Run the container image
 docker run --name phoriaapp -d -p 3001:8080 phoriaapp:latest
 ```
+
+> [!NOTE]
+> The tag `phoriaapp:latest` and name `phoriaapp` are just examples - you can use any tag or name that you like. Also please feel free to use a host port of your choosing rather than `3001` if you wish.
 
 The Phoria app running in the Docker container will now be accessible at [http://localhost:3001](http://localhost:3001) to test everything is working as expected.
 
@@ -177,12 +180,12 @@ azd init
 Then you can proceed through the prompts to setup azd:
 
 * You should be asked how you want to initialise your app - choose "Use code in the current directory"
-  * This may not detect the correct services initially so pay attention before you proceed - you can add and remove services using the prompts provided - what we want is to add just the Phoria dotnet Web App
-  * For example, when running `azd init` on the "Getting started" app a "Vite" service was detected in the root, but that had to be removed and the dotnet app under `./WebApp` had to be added instead
+  * This may not detect the correct services initially so pay attention before you proceed - you can add and remove services using the prompts provided - what you are aiming to do is to add just the Phoria dotnet Web App
+  * For example, when running `azd init` on the "Getting started" example project a "Vite" service was detected automatically by azd in the root of the repo, but that had to be removed and the dotnet app under `./WebApp` had to be added manually instead
 * `azd` should suggest hosting your app in Azure Container Apps - agree to proceed
 * You should then be prompted to enter a new environment name - enter what you would like here
 
-`azd` will then initialise your app by creating and modifying some files in your repository. The ones we care about are:
+`azd` will then initialise your app by creating and modifying some files in your repository. The ones we want to draw your attention to are:
 
 * The `infra` directory - this contains the Bicep files that describe the Azure resources that will be provisioned
 * The `azure.yaml` file - this contains the deployment configuration for your app
@@ -191,11 +194,15 @@ Then you can proceed through the prompts to setup azd:
 Any other files produced by the initialisation process are not relevant to this guide and you can decide if you want to keep them or not.
 
 > [!TIP]
-> Feel free to take a look through the `infra` directory if you are interested in how the Azure resources are described, but we won't be going into detail about that in this guide. The idea is that `azd` gives you everything that you need to get started quickly and easily, but if you want to dig deeper and customise things further you can absolutely do that. You can also use [Terraform instead of Bicep](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/use-terraform-for-azd) if you prefer.
+> Feel free to take a look through the `infra` directory if you are interested in how the Azure resources are described, but we won't be going into detail about that in this guide.
+> 
+> The idea is that `azd` gives you everything that you need to get started quickly and easily, but if you want to dig deeper and customise things further you can absolutely do that.
+> 
+> You can also use [Terraform instead of Bicep](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/use-terraform-for-azd) if you prefer.
 >
 > This guide also isn't aiming to be a guide to `azd` itself so please refer to the official documentation if you have more specific questions.
 
-You will need to make some changes to the `azure.yaml` file to use the Dockerfile that you created earlier. Here is an example of what the `azure.yaml` file should look like - the only part you should need to add is the `docker` section for the `web-app` service:
+You will need to make some changes to the `azure.yaml` file for `azd` to use the Dockerfile that you created earlier. Here is an example of what the `azure.yaml` file should look like - the only part you should need to add is the `docker` section for the `web-app` service:
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
@@ -212,6 +219,9 @@ services:
       path: ./Dockerfile
       context: ../
 ```
+
+> [!NOTE]
+> The `path` should be the path to the Dockerfile that you created earlier, and the `context` should be the path to the root of your repository. Both of these paths are relative to the root of the service.
 
 ### Deploy with azd
 
@@ -239,3 +249,7 @@ If you don't want to keep the resources that were provisioned you can run the fo
 ```shell
 azd down --purge
 ```
+
+### Next steps
+
+You may wish to [configure and use `azd` in a CI/CD pipeline](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/configure-devops-pipeline) to automate the deployment of your Phoria app to Azure Container Apps.

--- a/docs/guides/directives.md
+++ b/docs/guides/directives.md
@@ -1,4 +1,4 @@
-# Client Entry
+# Directives
 
 > [!WARNING]
 > This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -9,13 +9,14 @@ There are two ways you can get started:
 
 You can use [giget](https://unjs.io/packages/giget) to quickly clone an example project:
 
-`npx giget@latest gh:cmeeg/phoria-examples/examples/{example-name} {dir}`
+```shell
+npx giget@latest gh:cmeeg/phoria-examples/examples/<example_name> <target_dir>
+```
 
 > [!IMPORTANT]
 > You will need to replace:
-> 
-> * `{example-name}` with the folder name of the [example project you want to clone](https://github.com/CMeeg/phoria-examples/tree/main/examples)
-> * `{dir}` with the name of the local directory you want to clone the example project to
+> * `<example_name>` with the directory name of the [example project you want to clone](https://github.com/CMeeg/phoria-examples/tree/main/examples)
+> * `<target_dir>` with the name of the local directory you want to clone the example project to
 
 ## Manually add Phoria to an existing dotnet project
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -11,7 +11,7 @@ You can use [giget](https://unjs.io/packages/giget) to quickly clone an example 
 
 `npx giget@latest gh:cmeeg/phoria-examples/examples/{example-name} {dir}`
 
-> [!NOTE]
+> [!IMPORTANT]
 > You will need to replace:
 > 
 > * `{example-name}` with the folder name of the [example project you want to clone](https://github.com/CMeeg/phoria-examples/tree/main/examples)
@@ -22,7 +22,7 @@ You can use [giget](https://unjs.io/packages/giget) to quickly clone an example 
 Phoria can be added to any dotnet (>= v8) MVC or Razor Pages web app. We assume that you already have an existing dotnet web app that you want to add Phoria to, but for the purpose of this guide we will create a new web app and solution (imaginatively) called "Getting Started". You can substitute "Getting Started" for your own project / solution name wherever you see that referenced in the guide.
 
 > [!NOTE]
-> This guide will not cover some aspects of setting up a new project such as configuring git or VS Code or linting or testing tools as it is assumed that you will add and configure these things as you go or when you're ready based on your own preferences.
+> This guide will not cover some aspects of setting up a new project such as configuring Git or VS Code or linting or testing tools as it is assumed that you will add and configure these things as you go or when you're ready based on your own preferences.
 >
 > You can use the [getting-started](https://github.com/CMeeg/phoria-examples/tree/main/examples/getting-started) example project as a reference if you wish, which is a complete example of a project created using this guide.
 
@@ -52,8 +52,8 @@ dotnet new sln --name GettingStarted --output .
 dotnet sln add ./WebApp/WebApp.csproj
 ```
 
-> [!NOTE]
-> You will need to substitute the solution and project names used in the rest of this guide with the names of your own solution and web app project.
+> [!IMPORTANT]
+> You will need to substitute the solution and project names used in the rest of this guide with the names of your own solution and web app project. You may also need to adjust paths depending on the file structure of your projects and solution.
 
 ### Add Vite
 
@@ -201,7 +201,7 @@ registerComponents({
 ```
 
 > [!NOTE]
-> You may have noticed/guessed that the `ui` folder is the [root](https://vite.dev/config/shared-options.html#root) folder for Vite - this is where we will be placing all of our code related to our UI components. The name and location of the folder is a default used by Phoria that [can be changed](./configuration.md) and you can optionally use workspaces should you wish to do so.
+> You may have noticed/guessed that the `WebApp/ui` folder is the [root](https://vite.dev/config/shared-options.html#root) folder for Vite - this is where we will be placing all of our code related to our UI components. The name and location of the folder is a default used by Phoria that [can be changed](./configuration.md) and you can optionally use workspaces should you wish to do so.
 
 ### Add Phoria Server
 
@@ -215,7 +215,7 @@ pnpm add h3 listhen
 pnpm add -D @types/node tsx
 ```
 
-And add a separate TypeScript config file for the Phoria Server at the root of the repo `tsconfig.server.json`:
+And add a separate TypeScript config file for the Phoria Server at the root of the repo in `tsconfig.server.json`:
 
 ```json
 {
@@ -436,169 +436,35 @@ export { renderPhoriaIsland }
 >
 > The `island.render()` function does accept a custom render strategy if you need further control over it, for example if you are using a library like [styled components](https://styled-components.com/docs/advanced#server-side-rendering).
 
-### Configure the Phoria Web App
+### Add Phoria to the dotnet web app
 
-TODO
+Now we will add Phoria to the dotnet web app. From this point on we will refer to it as the [Phoria Web App](./phoria-web-app.md), which is just a way of saying a dotnet web app with the `Phoria` NuGet package installed and configured.
 
-### Add Phoria Islands
-
-TODO
-
-### Run the Phoria Web App
-
-TODO
-
-The Phoria Server is a Node script that starts a [h3](https://h3.unjs.io/) server and listens for CSR (Client Side Rendering) and SSR (Server Side Rendering) requests that are proxied through to it from the Phoria web app.
-
-> [!NOTE]
-> The Phoria libraries that you are about to install expose request handlers that are consumed by the server, but you own the server so feel free to extend it and use it for other things should you wish.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Next we will make some minor amends to the Scaffold output:
+First we need to add the Phoria NuGet package to the web app:
 
 ```shell
-# Delete the following files
-src
-├── index.css
-├── main.tsx
-index.html
-
-# Move the `public` and `src` folders under a `ui` folder
-ui
-├── public
-└── src
-
+dotnet add WebApp/WebApp.csproj package Phoria
 ```
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-```shell
-# Add the Phoria NuGet package to the web app
-dotnet add WebApp.csproj package Phoria
-```
-
-
-
-TODO: Mention that recommendation is to use workspaces, but Getting Started app will not because no assumption will be made that you are or want to use workspaces. Include an optional section to add workspaces at the end.
-
-
-
-
-
-
-
-
-
-### Phoria Web App
-
-Now we will set up the [Phoria Web App](./phoria-web-app.md), which is just a way of saying a dotnet web app with the `Phoria` NuGet package installed and configured.
-
-
-
-#### Configure the web app
-
-Phoria is added to your app via the `WebApplicationBuilder` and configured in `appsettings.json`.
-
-> [!TIP]
-> Phoria can be configured programmatically via the `WebApplicationBuilder`, but it's recommended to use `appsettings.json` because then the `phoria` Vite plugin and the Phoria `server.ts` can read and share that configuration.
-
-Either copy and paste the code below or edit your `Program.cs` file to add the lines that are preceded by a comment:
-
-```csharp
-// Add a using statement
-using Phoria;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddRazorPages();
-
-// Add Phoria services
-builder.Services.AddPhoria();
-
-var app = builder.Build();
-
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler("/Error");
-
-    app.UseHsts();
-}
-
-app.UseHttpsRedirection();
-app.UseStaticFiles();
-
-app.UseRouting();
-
-app.UseAuthorization();
-
-app.MapRazorPages().WithStaticAssets();
-
-// WebSockets are required for the Vite Dev Server's HMR (Hot Module Reload) feature
-if (app.Environment.IsDevelopment())
-{
-    app.UseWebSockets();
-}
-
-// The order of the Phoria middleware matters so we will place it last
-app.UsePhoria();
-
-app.Run();
-```
-
-Add the following section to your `appsettings.json` file:
+Then add the following section to `WebApp/appsettings.json`:
 
 ```json
 {
-  // ... Existing settings ...
-
-  // Add the Phoria section
   "phoria": {
+    "root": "WebApp/ui",
     "entry": "src/entry-client.ts",
     "ssrEntry": "src/entry-server.ts"
   }
 }
 ```
 
-And the following to your `appsettings.Development.json` file:
+> [!NOTE]
+> Any [configuration](./configuration.md) option that is not set explicitly will fallback to a default value except for `entry` and `ssrEntry` because there are no sensible defaults for these options.
+
+And the following to `WebApp/appsettings.Development.json`:
 
 ```json
 {
-  // ... Existing settings ...
-
-  // Add the Phoria section
   "phoria": {
     "server": {
       "https": true
@@ -608,66 +474,81 @@ And the following to your `appsettings.Development.json` file:
 ```
 
 > [!NOTE]
-> Any [configuration](./configuration.md) option that is not set explicitly will fallback to a default value except for `entry` and `ssrEntry` because there are no sensible defaults for these options. The `https` option will default to `false` so we are setting it here because we want our Phoria Server to use `https` in development.
+> The `https` option will default to `false` so we are setting it here because we want our Phoria Server to use `https` in development.
 
-#### Add the Phoria Tag Helpers
+Then we will modify `WebApp/Program.cs` to register Phoria services:
+
+```csharp
+// Add a using statement
+using Phoria;
+
+// Add Phoria services
+builder.Services.AddPhoria();
+
+// WebSockets support is required for Vite HMR (hot module reload)
+if (app.Environment.IsDevelopment())
+{
+    app.UseWebSockets();
+}
+
+// The order of the Phoria middleware matters so we will place this just before `app.Run()`
+app.UsePhoria();
+```
+
+> [!TIP]
+> Phoria can be configured programmatically via `AddPhoria`, but it's recommended to use `appsettings` because then the `phoria` Vite plugin and the Phoria Server can read that same configuration from the `appsettings.*.json` files rather than having to duplicate it in each place.
+
+### Add the Phoria Tag Helpers
 
 The `Phoria` NuGet package contains a set of [Tag Helpers](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro) for:
 
 * Rendering script and style tags from your [Client Entry](#add-client-entry) script
 * Rendering [preload directives](https://vite.dev/guide/ssr#generating-preload-directives) for your scripts and styles to avoid a "Flash Of Unstyled Content" (FOUC)
-  * This only applies to the [production](./build-for-production.md) build
 
-We will add these Tag Helpers to our Layout:
-
-* Edit `Pages/Shared/_ViewImports.cshtml`
-* Add the following lines and save:
+Add the following to `WebApp/Pages/_ViewImports.cshtml`:
 
 ```html
 @using Phoria.Islands
 @addTagHelper *, Phoria
 ```
 
-* Edit `Pages/Shared/_Layout.cshtml`
-* Add the following Tag Helpers just before the closing `</head>` tag:
+Add the following Tag Helpers to `WebApp/Pages/Shared/_Layout.cshtml` just before the closing `</head>` tag:
 
 ```html
 <phoria-island-styles />
 <phoria-island-preload />
 ```
 
-* Add the following Tag Helper just before the closing `</body>` tag:
+And the following Tag Helper to `WebApp/Pages/Shared/_Layout.cshtml` just before the closing `</body>` tag:
 
 ```html
 <phoria-island-scripts />
 ```
 
-Phoria is now setup and ready and you can start rendering Phoria Islands.
-
-### Adding Phoria Islands
+### Add a Phoria Island
 
 The `Phoria` NuGet package contains a Tag Helper for rendering Phoria Islands. The Tag Helper will take care of everything to do with rendering the component:
 
 * Serialising data passed inline or from the view model as `props` for the component
-* Requesting an SSR response from the Phoria Server, if required (Islands can be CSR only)
-* Hydrating the component on the client, if required (Islands can be SSR only)
+* Requesting an SSR response from the Phoria Server (if required, Islands can be CSR only)
+* Hydrating the component on the client (if required, Islands can be SSR only)
 
-For the purpose of this guide we will render the `Counter` component that we created from the Vite Project Scaffold.
+For the purpose of this guide we will render the `Counter` component that we [added and registered](#add-a-ui-component) earlier.
 
-Edit `Pages/Index.cshtml`:
-
-* Add the following Tag Helper at the bottom of the file:
+Add the following Tag Helper to `WebApp/Pages/Index.cshtml` at the bottom of the file:
 
 ```html
-<phoria-island component="Counter" client="Client.Load"></phoria-island>
+<phoria-island component="Counter" client="Client.Load" props="new { StartAt = 5 }"></phoria-island>
 ```
 
-> [!NOTE]
-> The `component` name must match the name of the component we added to the [Component Register](#add-and-register-a-component). The `client` directive is set to `Client.Load` because we want this component to hydrate on page load.
+> [!TIP]
+> The value of `component` must match a key in your component register. In our case we registered the `Counter` component using the key `Counter`.
 > 
-> Please see the [Phoria Islands](./phoria-islands.md) guide for a description of available client directives and other options.
+> The value of `client` is set to `Client.Load` because this component uses React state and we want this component to hydrate on page load. You can try using other client directives if you want to see how they work.
+>
+> The value of `props` is an anonymous object that will be serialised and passed to the component as `props` to demonstrate how you can pass data from your dotnet web app to your Islands. The data is hardcoded here, but can come from any source and passed through your view model.
 
-### Running the Phoria Web App
+### Run the Phoria Web App
 
 Now we can run our app and see Phoria in action.
 
@@ -681,18 +562,18 @@ dotnet dev-certs https --trust
 pnpm run dev
 
 # Start the Phoria Web App (you will need to run this in a separate terminal instance/tab to the Phoria Server)
-dotnet run --project WebApp.csproj --launch-profile https
+dotnet run --project WebApp/WebApp.csproj --launch-profile https
 ```
 
 > [!TIP]
-> The `dotnet run` command doesn't automatically launch the browser unfortunately, but you can find the URL for the web app in the terminal output or by looking in your `launchSettings.json` file.
+> The `dotnet run` command doesn't automatically launch the browser unfortunately, but you can find the URL for the web app in the terminal output or by looking in your `WebApp/Properties/launchSettings.json` file.
 
 Now you will be able to navigate to the web app in your browser and:
 
 * See the `Counter` component rendered via React
-* See the styles and assets imported by the React component
-  * Though granted it doesn't look great because it's all mixed in with the styles from the dotnet web app!
-* Click on the button that reads `count is 0` to see that the component has hydrated and is reacting to state changes
+  * View the page source to see the SSR response from the Phoria Server
+* Click on the button to see that the component has hydrated and is reacting to state changes
+  * The first time you run the app Vite may take a couple of seconds to optimise dependencies so you may see a delay before the component hydrates
 * Make a change to the `Counter.tsx` component to see HMR working
 
 ### Next steps

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -20,7 +20,9 @@ npx giget@latest gh:cmeeg/phoria-examples/examples/<example_name> <target_dir>
 
 ## Manually add Phoria to an existing dotnet project
 
-Phoria can be added to any dotnet (>= v8) MVC or Razor Pages web app. We assume that you already have an existing dotnet web app that you want to add Phoria to, but for the purpose of this guide we will create a new web app and solution (imaginatively) called "Getting Started". You can substitute "Getting Started" for your own project / solution name wherever you see that referenced in the guide.
+Phoria can be added to any dotnet (>= v8) MVC or Razor Pages web app. We assume that you already have an existing dotnet web app that you want to add Phoria to, but for the purpose of this guide we will create a new web app and solution (imaginatively) called "Getting Started" and use that as our "existing project".
+
+You can substitute "Getting Started" for your own project / solution name wherever you see that referenced in the guide.
 
 > [!NOTE]
 > This guide will not cover some aspects of setting up a new project such as configuring Git or VS Code or linting or testing tools as it is assumed that you will add and configure these things as you go or when you're ready based on your own preferences.
@@ -29,16 +31,16 @@ Phoria can be added to any dotnet (>= v8) MVC or Razor Pages web app. We assume 
 
 ### Prerequisites
 
-There is some prerequisite software you will need to have installed before we go any further:
+There is some prerequisite software you will need to have installed before you go any further:
 
 * **dotnet** - `v8` or higher
 * **Node.js** - `v18.17.1` or `v20.3.0`, `v22.0.0` or higher
-  * We recommend using [fnm](https://github.com/Schniz/fnm) or [nvm](https://github.com/nvm-sh/nvm) to manage Node installations
+  * If you're not already, we recommend using [fnm](https://github.com/Schniz/fnm) or [nvm](https://github.com/nvm-sh/nvm) to manage Node installations
 * **Node package manager** - We recommend [pnpm](https://pnpm.io/), but npm will work just as well
-* **Code editor** - We recommend [VS Code](https://code.visualstudio.com/)
+* **Code editor** - We recommend [VS Code](https://code.visualstudio.com/), but you can use any code editor you like
 * **Terminal** - You will need to be able to run CLI tools through a terminal of your choice
 
-You will also need an existing dotnet web app. If you do not already have an existing dotnet web app then we recommend [cloning an example project](#clone-an-example-project) rather than following this manual process, but if you still want to proceed you can create a new web app using the dotnet CLI:
+You will also need an existing dotnet web app. If you do not already have an existing dotnet web app then we recommend [cloning an example project](#clone-an-example-project) rather than following the rest of this guide, but if you still want to proceed you can create a new web app using the dotnet CLI:
 
 
 ```shell
@@ -58,12 +60,12 @@ dotnet sln add ./WebApp/WebApp.csproj
 
 ### Add Vite
 
-The first thing we are going to do is add [Vite](https://vite.dev/) to the repo and configure Phoria via Vite plugins. The plugins configure Vite's `client` and `ssr` [environments](https://vite.dev/guide/api-environment.html) and register specific Vite plugins for the UI framework(s) that you want to use.
+The first thing you will need to do is add [Vite](https://vite.dev/) to the repo and configure Phoria via Vite plugins. The plugins configure Vite's `client` and `ssr` [environments](https://vite.dev/guide/api-environment.html) and register specific Vite plugins for the UI framework(s) that you want to use.
 
 > [!NOTE]
-> In this guide we will choose React as our UI framework, but you can choose any [supported UI framework](./supported-ui-frameworks.md).
+> In this guide we have chosen React as the UI framework, but you can choose any [supported UI framework](./supported-ui-frameworks.md).
 > 
-> We will also be using pnpm, fnm and VS Code, but feel free to substitute the tools (and therefore commands used) based on your preferences.
+> We used pnpm, fnm and VS Code, but feel free to substitute the tools (and therefore commands used) based on your preferences.
 > 
 > The guide was written against code samples developed on a Windows machine with PowerShell so some shell commands may need adapting to your OS or shell of choice also, but an attempt has been made to make the guide as platform-agnostic as possible.
 
@@ -87,13 +89,13 @@ pnpm add @phoria/phoria @phoria/phoria-react react react-dom
 pnpm add -D @phoria/vite-plugin-dotnet-dev-certs @types/react @types/react-dom @vitejs/plugin-react typescript vite vite-tsconfig-paths
 ```
 
-Then we will need to make some manual adjustments to the generated `package.json` file:
+Then you will need to make some manual adjustments to the generated `package.json` file:
 
 * Add `"private": true`
 * Add `"type": "module"`
 * Remove `"main": "index.js"`
 
-Next add a `vite.config.ts` file to the root of your repo:
+Then add a `vite.config.ts` file to the root of your repo:
 
 ```ts
 import { phoriaReact } from "@phoria/phoria-react/vite"
@@ -159,7 +161,7 @@ And finally a `tsconfig.json` file to the root of your repo:
 
 ### Add a UI component
 
-We need to add a UI component to our repo that we will render in a Phoria Island. For the purpose of this guide we will use a simple React "Counter" component, but you can substitute that for something else if you want.
+You will need to add a UI component to your repo that will eventually render inside a Phoria Island. For the purpose of this guide we are using a simple React "Counter" component, but you can substitute that for something else if you want.
 
 We will create the component in the file `WebApp/ui/src/components/Counter/Counter.tsx`:
 
@@ -185,7 +187,7 @@ function Counter({ startAt }: CounterProps) {
 export { Counter }
 ```
 
-We also need to [register the component](./component-register.md) so that Phoria knows where to find it and how to render it. We will do this in the file `WebApp/ui/src/components/register.ts`:
+You will also need to [register the component](./component-register.md) so that Phoria knows where to find it and how to render it. Create the file `WebApp/ui/src/components/register.ts`:
 
 ```ts
 import { registerComponents } from "@phoria/phoria"
@@ -202,13 +204,13 @@ registerComponents({
 ```
 
 > [!NOTE]
-> You may have noticed/guessed that the `WebApp/ui` folder is the [root](https://vite.dev/config/shared-options.html#root) folder for Vite - this is where we will be placing all of our code related to our UI components. The name and location of the folder is a default used by Phoria that [can be changed](./configuration.md) and you can optionally use workspaces should you wish to do so.
+> You may have noticed/guessed that the `WebApp/ui` folder is the [root](https://vite.dev/config/shared-options.html#root) folder for Vite - this is where we will be placing all of the code related to our UI components. The name and location of the folder is a default used by Phoria that [can be changed](./configuration.md). [Workspaces](./workspaces.md) (e.g. pnpm workspaces) are also supported by Phoria, which can help simplify configuration and may be a better fit for a typical dotnet solution/project directory structure.
 
 ### Add Phoria Server
 
 The Phoria Server is a [h3](https://h3.unjs.io/) server that effectively runs as a "sidecar" to your web app by running inside its own `node` process. It delegates requests to CSR, SSR or static file handlers as required, which use Vite's Dev Server in development and the build output from Vite when in production.
 
-First we need to add some more dependencies to our repo:
+First you will need to add some more dependencies to your repo:
 
 ```shell
 pnpm add h3 listhen
@@ -245,7 +247,7 @@ And add a separate TypeScript config file for the Phoria Server at the root of t
 }
 ```
 
-Then we will create the Phoria Server script at `WebApp/ui/src/server.ts`:
+Then you will need to create the Phoria Server script at `WebApp/ui/src/server.ts`:
 
 ```ts
 import { dirname } from "node:path"
@@ -384,7 +386,7 @@ export { app, listener }
 > [!TIP]
 > Please feel free to read through the comments in the server script to get a feel for what it does.
 
-Finally we will add an entry to our `scripts` in `package.json` to run the Phoria Server in our development environment:
+Finally you will need to add an entry to your `scripts` in `package.json` to run the Phoria Server in your development environment:
 
 ```json
 "scripts": {
@@ -399,7 +401,7 @@ The [Client Entry](./client-entry.md) is the entrypoint for the browser and is r
 You can also choose to initialise other client-side code here, or import "global" CSS, if you wish.
 
 > [!NOTE]
-> Phoria supports client-only, server-only and "isomorphic" rendering of components in Islands. Server-only is the default, but you can opt-in to client-side rendering on an Island-by-Island basis using one or more client directives such as "client only", "on load", "on idle", "on visible", "on match media". If an Island is server-only then it will not hydrate on the client and therefore does not request any JavaScript.
+> Phoria supports client-only, server-only and "isomorphic" rendering of components in Islands. Server-only is the default, but you can opt-in to client-side rendering on an Island-by-Island basis using one or more client [directives](./directives.md) such as "client only", "on load" etc. If an Island is server-only then it will not hydrate on the client and therefore does not request any additional JavaScript.
 
 Add a Client Entry file at `WebApp/ui/src/entry-client.ts`:
 
@@ -412,7 +414,7 @@ PhoriaIsland.register()
 ```
 
 > [!NOTE]
-> `PhoriaIsland` is a custom HTML element that is used to hydrate the components that you have registered in your component registration file (i.e. `./components/register`) for Islands that you have opted-in to client-side rendering.
+> `PhoriaIsland` is a custom HTML element that is used to hydrate the components that you have [registered](#add-a-ui-component) in your component registration file (i.e. `./components/register`) for Islands that you have opted-in to client-side rendering.
 
 ### Add Server Entry
 
@@ -439,9 +441,9 @@ export { renderPhoriaIsland }
 
 ### Add Phoria to the dotnet web app
 
-Now we will add Phoria to the dotnet web app. From this point on we will refer to it as the [Phoria Web App](./phoria-web-app.md), which is just a way of saying a dotnet web app with the `Phoria` NuGet package installed and configured.
+Now you can add Phoria to your dotnet web app. From this point on we will refer to it as the [Phoria Web App](./phoria-web-app.md), which is just a way of saying a dotnet web app with the `Phoria` NuGet package installed and configured.
 
-First we need to add the Phoria NuGet package to the web app:
+First you will need to add the Phoria NuGet package to the web app:
 
 ```shell
 dotnet add WebApp/WebApp.csproj package Phoria
@@ -477,7 +479,7 @@ And the following to `WebApp/appsettings.Development.json`:
 > [!NOTE]
 > The `https` option will default to `false` so we are setting it here because we want our Phoria Server to use `https` in development.
 
-Then we will modify `WebApp/Program.cs` to register Phoria services:
+Then you will need to modify `WebApp/Program.cs` to register Phoria services. Add the following code in the appropriate places (i.e. the below does not represent a complete `Program.cs` file, just the parts you need to add to configure Phoria):
 
 ```csharp
 // Add a using statement
@@ -534,7 +536,7 @@ The `Phoria` NuGet package contains a Tag Helper for rendering Phoria Islands. T
 * Requesting an SSR response from the Phoria Server (if required, Islands can be CSR only)
 * Hydrating the component on the client (if required, Islands can be SSR only)
 
-For the purpose of this guide we will render the `Counter` component that we [added and registered](#add-a-ui-component) earlier.
+For the purpose of this guide we will render the `Counter` component that we [added and registered](#add-a-ui-component) earlier. You will need to adapt the below if you registered a different component.
 
 Add the following Tag Helper to `WebApp/Pages/Index.cshtml` at the bottom of the file:
 
@@ -543,15 +545,15 @@ Add the following Tag Helper to `WebApp/Pages/Index.cshtml` at the bottom of the
 ```
 
 > [!TIP]
-> The value of `component` must match a key in your component register. In our case we registered the `Counter` component using the key `Counter`.
+> The value of `component` must match a key in your [component register](#add-a-ui-component). In our case we registered the `Counter` component using the key `Counter`.
 > 
-> The value of `client` is set to `Client.Load` because this component uses React state and we want this component to hydrate on page load. You can try using other client directives if you want to see how they work.
+> The value of `client` is set to `Client.Load` because this component uses React state and we want this component to hydrate on page load. You can try using other client [directives](./directives.md) if you want to see how they work.
 >
 > The value of `props` is an anonymous object that will be serialised and passed to the component as `props` to demonstrate how you can pass data from your dotnet web app to your Islands. The data is hardcoded here, but can come from any source and passed through your view model.
 
 ### Run the Phoria Web App
 
-Now we can run our app and see Phoria in action.
+Now you can run your app and see Phoria in action.
 
 From your terminal run:
 
@@ -572,9 +574,9 @@ dotnet run --project WebApp/WebApp.csproj --launch-profile https
 Now you will be able to navigate to the web app in your browser and:
 
 * See the `Counter` component rendered via React
-  * View the page source to see the SSR response from the Phoria Server
+* View the page source to see the SSR response from the Phoria Server
 * Click on the button to see that the component has hydrated and is reacting to state changes
-  * The first time you run the app Vite may take a couple of seconds to optimise dependencies so you may see a delay before the component hydrates
+  * The first time you run the app Vite may take a couple of seconds to optimise dependencies so you may see a delay before the component hydrates - you can see this happening in the terminal where you started the Phoria Server
 * Make a change to the `Counter.tsx` component to see HMR working
 
 ### Next steps

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -564,7 +564,8 @@ dotnet dev-certs https --trust
 # Start the Phoria Server
 pnpm run dev
 
-# Start the Phoria Web App (you will need to run this in a separate terminal instance/tab to the Phoria Server)
+# Start the Phoria Web App
+# You will need to run this in a separate terminal instance/tab to the Phoria Server
 dotnet run --project WebApp/WebApp.csproj --launch-profile https
 ```
 

--- a/docs/guides/phoria-islands.md
+++ b/docs/guides/phoria-islands.md
@@ -1,9 +1,4 @@
 # Phoria Islands
 
-TODO
-
-* The `phoria-island` tag helper -  Client directives, props etc
-* Component registration
-* Client directives
-* Props
-* CSR, SSR, both
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/phoria-server.md
+++ b/docs/guides/phoria-server.md
@@ -1,3 +1,4 @@
 # Phoria Server
 
-TODO
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/phoria-web-app.md
+++ b/docs/guides/phoria-web-app.md
@@ -1,3 +1,4 @@
 # Phoria Web App
 
-TODO
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/server-entry.md
+++ b/docs/guides/server-entry.md
@@ -1,3 +1,4 @@
 # Server Entry
 
-TODO
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/supported-ui-frameworks.md
+++ b/docs/guides/supported-ui-frameworks.md
@@ -1,24 +1,25 @@
 # Supported UI frameworks
 
-This guide discusses the UI frameworks supported by Phoria, and how to get started with them.
+Phoria supports:
+
+* [React](#react)
+* [Svelte](#svelte)
+* [Vue](#vue)
+
+> [!NOTE]
+> Support for other frameworks may be added in the future. If you have a specific request, please raise an issue.
 
 ## React
 
-TODO
-
-* Specific notes about React
-* Link to plugin docs (that also need to be written)
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.
 
 ## Svelte
 
-TODO
-
-* Specific notes about Svelte
-* Link to plugin docs (that also need to be written)
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.
 
 ## Vue
 
-TODO
-
-* Specific notes about Vue
-* Link to plugin docs (that also need to be written)
+> [!WARNING]
+> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/docs/guides/workspaces.md
+++ b/docs/guides/workspaces.md
@@ -1,4 +1,4 @@
-# Client Entry
+# Workspaces
 
 > [!WARNING]
 > This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.

--- a/e2e/framework-multiple/WebApp/ui/src/server.ts
+++ b/e2e/framework-multiple/WebApp/ui/src/server.ts
@@ -1,4 +1,4 @@
-import path from "node:path"
+import { dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import {
 	createPhoriaCsrRequestHandler,
@@ -13,7 +13,7 @@ import { type ListenOptions, listen } from "listhen"
 // Get environment and appsettings
 
 const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+const __dirname = dirname(__filename)
 
 const nodeEnv = process.env.NODE_ENV ?? "development"
 const isProduction = nodeEnv === "production"

--- a/e2e/framework-multiple/vite.server.config.ts
+++ b/e2e/framework-multiple/vite.server.config.ts
@@ -1,4 +1,4 @@
-import path from "node:path"
+import { join } from "node:path"
 import { parsePhoriaAppSettings } from "@phoria/phoria/server"
 import { type UserConfig, defineConfig } from "vite"
 
@@ -6,7 +6,7 @@ export default defineConfig(async () => {
 	const dotnetEnv = process.env.DOTNET_ENVIRONMENT ?? process.env.ASPNETCORE_ENVIRONMENT ?? "development"
 	const appsettings = await parsePhoriaAppSettings({
 		environment: dotnetEnv,
-		cwd: path.join(process.cwd(), "WebApp")
+		cwd: join(process.cwd(), "WebApp")
 	})
 
 	// https://vite.dev/config/


### PR DESCRIPTION
* Rewrite the Getting started docs to describe two routes - clone an example using giget or manual setup
* Update the Building for production guide to match up to the changes made to the Getting started example app
* Add a Deployment guide for deploying to Azure Container Apps
* Add an About section to the main README
* Fix some general grammatical inconsistencies