### PR TITLE
Improve DX of creating custom Phoria Islands

### DIFF
--- a/.changeset/mean-windows-arrive.md
+++ b/.changeset/mean-windows-arrive.md
@@ -1,0 +1,5 @@
+---
+"phoria-dotnet": patch
+---
+
+Add `PhoriaIslandComponentFactory`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,10 +5,12 @@
 		"ASPNETCORE",
 		"Blazor",
 		"cmeeg",
+		"deserialised",
 		"FOUC",
 		"giget",
 		"listhen",
 		"Phoria",
+		"POCO",
 		"Tinylibs",
 		"unjs"
 	],

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ Or feel free to choose any one of the [other examples available](https://github.
 ## Usage
 
 * [Getting started](./docs/guides/getting-started.md)
+* [Creating Phoria Island components](./docs/guides/creating-phoria-island-components.md)
+* [Phoria Island directives](./docs/guides/directives.md)
 * [Building for production](./docs/guides/building-for-production.md)
 * [Deployment](./docs/guides/deployment.md)
 
 > [!NOTE]
-> The Usage documentation is a work in progress and will be expanded on in time. If there is something missing that needs clarification while it is being worked on, or if you have an idea or request for documentation not mentioned below, please raise an issue.
+> The Usage documentation is a work in progress and will be expanded on in time. If there is something missing that needs clarification while it is being worked on, or if you have an idea or request for documentation, please raise an issue.
 
 ## About Phoria
 

--- a/docs/guides/creating-phoria-island-components.md
+++ b/docs/guides/creating-phoria-island-components.md
@@ -1,0 +1,199 @@
+# Creating Phoria Island components
+
+A Phoria Island allows you to easily and efficiently render islands of interactivity using modern UI frameworks within your dotnet web app (Razor Pages or MVC) using both Client Side Rendering (CSR) and/or Server Side Rendering (SSR).
+
+The Phoria NuGet packages includes a `PhoriaIslandTagHelper`, which can be used to render any Phoria Island, for example:
+
+```html
+<phoria-island component="Counter" client="Client.Load" props="new { StartAt = 5 }"></phoria-island>
+```
+
+Also included is a `PhoriaIslandComponentFactory` that can be used to create your own Tag Helpers or View Components to render a specific Phoria Island component, for example:
+
+```html
+<counter start-at="5" />
+```
+
+This guide will walk you through both methods of creating Phoria Island components.
+
+## Create the UI component
+
+> [!IMPORTANT]
+> For the purpose of this guide we will assume that you have created your Phoria app using one of the [example projects](./getting-started.md#clone-an-example-project) and the sample code is based on the `framework-react` example.
+> 
+> The same principles apply to any Phoria project, but you may need to adjust the code samples or file paths to suit your own project.
+
+First of all you will need to create your UI component. We will create a simple counter component in a new file `WebApp/ui/src/components/Counter/Counter.tsx`:
+
+```tsx
+import { useState } from "react"
+
+interface CounterProps {
+  startAt?: number
+}
+
+function Counter({ startAt }: CounterProps) {
+  const [count, setCount] = useState(startAt ?? 0)
+
+  return (
+    <div>
+      <button type="button" onClick={() => setCount((value) => value + 1)}>
+        count is {count}
+      </button>
+    </div>
+  )
+}
+
+export { Counter }
+```
+
+> [!TIP]
+> You may wish to use a tool such as [Storybook](https://storybook.js.org/) when developing your UI components, which allows you to develop and test UI components in isolation so that you can ensure they are functioning as expected before using them in your Phoria app.
+
+## Register the UI component
+
+You will then need to [register the component](./component-register.md) so that your Phoria Island's know where to import it from. Edit the file `WebApp/ui/src/components/register.ts`:
+
+```ts
+import { registerComponents } from "@phoria/phoria"
+
+registerComponents({
+  Counter: {
+    loader: {
+      module: () => import("./Counter/Counter.tsx"),
+      component: (module) => module.Counter
+    },
+    framework: "react"
+  }
+})
+```
+
+This tells Phoria to register a component using the name `Counter`, which can be imported from `./Counter/Counter.tsx` using a named export `Counter`, and it uses the `react` framework.
+
+If your component uses a default export you can register it like this instead:
+
+```ts
+import { registerComponents } from "@phoria/phoria"
+
+registerComponents({
+  Counter: {
+    loader: () => import("./Counter/Counter.tsx"),
+    framework: "react"
+  }
+})
+```
+
+> [!TIP]
+> The object passed to `registerComponents` can be used to register multiple components so as you add components that you want to use in Phoria Islands you can just keep adding them here.
+
+## Render the UI component with the `PhoriaIslandTagHelper`
+
+Now you can render your component with a Phoria Island. Open any Razor Page or MVC view and add the following code:
+
+```html
+<phoria-island component="Counter" client="Client.Load" props="new { StartAt = 5 }"></phoria-island>
+```
+
+This will render component registered with the name `Counter`, server render the component and hydrate the component on page load, and set the `startAt` component prop to `5`.
+
+To explain the attributes of the `phoria-island` tag a little further:
+
+* `component` (required) - The name of the component to render, which must match a component [registered](#register-the-ui-component) via the `registerComponents` function
+* `client` (optional) - The [client directive](./directives.md) to use to hydrate the component, which if not supplied implies that the component should be server rendered only
+* `props` (optional) - The props to pass to the component, which can be any POCO (Plain Old CLR Object) that can be serialised to JSON and when deserialised must match the type of the component's props
+
+> [!TIP]
+> If this is just a one-off Phoria Island you may wish to stop there, but if you plan on using this component in multiple places across your app you may want to consider creating a custom Tag Helper or View Component to render the component, which we will cover in the next section.
+
+## Render the UI component with the `PhoriaIslandComponentFactory`
+
+Creating a custom [Tag Helper](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro) or [View Component](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/view-components) to render a Phoria Island component is recommended when you want to reuse the same component in multiple place across your app. It allows you to:
+
+* Encapsulate values for attributes such as `component` (name) and `client` (directive) for consistency
+* Add strongly-typed `props` so there is no chance of misspelling or mistyping prop names or values
+* Encapsulate any additional business logic or validation you may need when rendering the component
+
+To create a custom Tag Helper for the `Counter` component we can create a new class:
+
+```csharp
+public class CounterTagHelper : TagHelper
+{
+  private readonly IPhoriaIslandComponentFactory phoriaIslandFactory;
+
+  public int? StartAt { get; set; }
+
+  public CounterTagHelper(IPhoriaIslandComponentFactory phoriaIslandFactory)
+  {
+    this.phoriaIslandFactory = phoriaIslandFactory;
+  }
+
+  public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+  {
+    var props = new CounterProps
+    {
+      StartAt = StartAt ?? 0
+    };
+
+    PhoriaIslandHtmlContent island = await phoriaIslandFactory.CreateAsync("Counter", props, Client.Load);
+
+    output.TagName = null;
+    output.TagMode = TagMode.SelfClosing;
+
+    output.Content.SetHtmlContent(island);
+  }
+}
+```
+
+Or you can create a View Component:
+
+```csharp
+public class CounterViewComponent : ViewComponent
+{
+  private readonly IPhoriaIslandComponentFactory phoriaIslandFactory;
+
+  public CounterViewComponent(IPhoriaIslandComponentFactory phoriaIslandFactory)
+  {
+    this.phoriaIslandFactory = phoriaIslandFactory;
+  }
+
+  public async Task<IViewComponentResult> InvokeAsync(int? startAt)
+  {
+    var props = new CounterProps
+    {
+      StartAt = startAt ?? 0
+    };
+
+    PhoriaIslandHtmlContent island = await phoriaIslandFactory.CreateAsync("Counter", props, Client.Load);
+
+    return new HtmlContentViewComponentResult(island);
+  }
+}
+```
+
+> [!NOTE]
+> There is no particular advantage to using a Tag Helper or View Component over the other, it is more a matter of personal/team preference or down to your particular requirements.
+
+And a new class the model the component's props:
+
+```csharp
+public class CounterProps
+{
+  public int StartAt { get; set; }
+}
+```
+
+> [!TIP]
+> In this example we are accepting parameters to the Tag Helper and View Component that model the individual props and then constructing the `CounterProps` instance internally to create the Phoria Island, but you could also accept a single parameter that accepts an instance of `CounterProps` if you prefer.
+
+You can then use the Tag Helper or View Component in your Razor Pages or MVC views:
+
+```html
+<!-- Tag Helper -->
+<counter start-at="19" />
+
+<!-- View Component -->
+<vc:counter start-at="9" />
+```
+
+> [!TIP]
+> This assumes that you have exposed the Tag Helper or View Component to your pages/views by adding the appropriate `@addTagHelper` directive to your `_ViewImports.cshtml` file.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -94,10 +94,10 @@ COPY --from=uibuild /app .
 # Install node for Phoria Server
 ENV NODE_VERSION=22.11.0
 RUN apt-get -y update \
-	&& apt-get install -y curl \
-	&& curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION} -o nodesource_setup.sh | bash \
-	&& apt-get install -y --no-install-recommends nodejs \
-	&& apt-get clean
+  && apt-get install -y curl \
+  && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION} -o nodesource_setup.sh | bash \
+  && apt-get install -y --no-install-recommends nodejs \
+  && apt-get clean
 
 # Run the app
 USER $APP_UID
@@ -133,14 +133,14 @@ You can configure the Phoria Web App to start and monitor the Phoria Server `nod
 
 ```json
 {
-	"phoria": {
-		"server": {
-			"process": {
-				"command": "node",
-				"arguments": ["WebApp/ui/dist/server/server.js"]
-			}
-		}
-	}
+  "phoria": {
+    "server": {
+      "process": {
+        "command": "node",
+        "arguments": ["WebApp/ui/dist/server/server.js"]
+      }
+    }
+  }
 }
 ```
 

--- a/docs/guides/directives.md
+++ b/docs/guides/directives.md
@@ -1,4 +1,51 @@
 # Directives
 
-> [!WARNING]
-> This guide is a work in progress. This section is a placeholder for documentation that still needs to be written. If you have any questions in the meantime, please raise an issue.
+Phoria Islands support a number of client directives that allow you to control when and how your Islands are hydrated on the client.
+
+## Client directives
+
+Unless a client directive is specified, the default behaviour is to server render the component only and not hydrate on the client. In this case there will be no additional JavaScript added to the page to render the component. Therefore we recommend to only use client directives if the component does require hydration.
+
+### `Client.Load`
+
+Hydrates the component immediately on page load.
+
+```html
+<phoria-island component="Counter" client="Client.Load"></phoria-island>
+```
+
+### `Client.Idle(int? timeout)`
+
+Hydrates the component when the page has loaded and the `requestIdleCallback` event is fired.
+
+Optionally you can specify a timeout in milliseconds after which the component will be hydrated regardless of whether the browser is idle.
+
+```html
+<phoria-island component="Counter" client="Client.Idle()"></phoria-island>
+```
+
+### `Client.Visible(string? rootMargin)`
+
+Hydrates the component when the component has entered the user's viewport, which is determined using an `IntersectionObserver`.
+
+Optionally you can specify a `rootMargin` value, which is a margin (in pixels) around the component that will trigger the hydration rather than the component itself.
+
+```html
+<phoria-island component="Counter" client="Client.Visible()"></phoria-island>
+```
+
+### `Client.Media(string mediaQuery)`
+
+Hydrates the component when the specified CSS media query is matched.
+
+```html
+<phoria-island component="Counter" client="@(Client.Media("(max-width: 50em)"))"></phoria-island>
+```
+
+### `Client.Only`
+
+Hydrates the component only on the client and does not server render the component. Hydration will occur immediately on page load, similar to `Client.Load`.
+
+```html
+<phoria-island component="Counter" client="Client.Only"></phoria-island>
+```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -428,7 +428,7 @@ import "./components/register"
 import type { PhoriaIsland } from "@phoria/phoria/server"
 
 async function renderPhoriaIsland(island: PhoriaIsland) {
-	return await island.render()
+  return await island.render()
 }
 
 export { renderPhoriaIsland }

--- a/e2e/with-workspace/WebApp/Components/ReactCounterTagHelper.cs
+++ b/e2e/with-workspace/WebApp/Components/ReactCounterTagHelper.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Phoria.Islands;
+
+namespace WebApp.Components;
+
+public class ReactCounterTagHelper : TagHelper
+{
+	private readonly IPhoriaIslandComponentFactory phoriaIslandFactory;
+
+	public int? StartAt { get; set; }
+
+	public ReactCounterTagHelper(IPhoriaIslandComponentFactory phoriaIslandFactory)
+	{
+		this.phoriaIslandFactory = phoriaIslandFactory;
+	}
+
+	public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+	{
+		var props = new ReactCounterProps
+		{
+			StartAt = StartAt ?? 0
+		};
+
+		PhoriaIslandHtmlContent island = await phoriaIslandFactory.CreateAsync("ReactCounter", props, Client.Load);
+
+		output.TagName = null;
+		output.TagMode = TagMode.SelfClosing;
+
+		output.Content.SetHtmlContent(island);
+	}
+}

--- a/e2e/with-workspace/WebApp/Components/ReactCounterViewComponent.cs
+++ b/e2e/with-workspace/WebApp/Components/ReactCounterViewComponent.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using Phoria.Islands;
+
+namespace WebApp.Components;
+
+public class ReactCounterProps
+{
+	public int StartAt { get; set; }
+}
+
+public class ReactCounterViewComponent : ViewComponent
+{
+	private readonly IPhoriaIslandComponentFactory phoriaIslandFactory;
+
+	public ReactCounterViewComponent(IPhoriaIslandComponentFactory phoriaIslandFactory)
+	{
+		this.phoriaIslandFactory = phoriaIslandFactory;
+	}
+
+	public async Task<IViewComponentResult> InvokeAsync(int? startAt)
+	{
+		var props = new ReactCounterProps
+		{
+			StartAt = startAt ?? 0
+		};
+
+		PhoriaIslandHtmlContent island = await phoriaIslandFactory.CreateAsync("ReactCounter", props, Client.Load);
+
+		return new HtmlContentViewComponentResult(island);
+	}
+}

--- a/e2e/with-workspace/WebApp/Pages/Index.cshtml
+++ b/e2e/with-workspace/WebApp/Pages/Index.cshtml
@@ -14,6 +14,10 @@
 {
 	<div class="card">
 		<phoria-island component="ReactCounter" client="Client.Load" props="new { StartAt = 5 }"></phoria-island>
+
+		<vc:react-counter start-at="9" />
+
+		<react-counter start-at="19" />
 	</div>
 }
 @if (Model.ShowVueComponent)

--- a/e2e/with-workspace/WebApp/Pages/_ViewImports.cshtml
+++ b/e2e/with-workspace/WebApp/Pages/_ViewImports.cshtml
@@ -3,3 +3,4 @@
 @namespace WebApp.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Phoria
+@addTagHelper *, WebApp

--- a/packages/Phoria/Islands/PhoriaIslandComponentException.cs
+++ b/packages/Phoria/Islands/PhoriaIslandComponentException.cs
@@ -1,0 +1,9 @@
+namespace Phoria.Islands;
+public class PhoriaIslandComponentException
+	: Exception
+{
+	public PhoriaIslandComponentException(string message)
+		: base(message)
+	{
+	}
+}

--- a/packages/Phoria/Islands/PhoriaIslandComponentFactory.cs
+++ b/packages/Phoria/Islands/PhoriaIslandComponentFactory.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Options;
+using Phoria.Server;
+
+namespace Phoria.Islands;
+
+public interface IPhoriaIslandComponentFactory
+{
+	Task<PhoriaIslandHtmlContent> CreateAsync(
+		string component,
+		object? props,
+		PhoriaIslandClientDirective? client);
+}
+
+public class PhoriaIslandComponentFactory(
+	IPhoriaServerMonitor serverMonitor,
+	IPhoriaIslandScopedContext scopedContext,
+	IPhoriaIslandSsr phoriaIslandSsr,
+	IOptions<PhoriaOptions> options)
+	: IPhoriaIslandComponentFactory
+{
+	private readonly IPhoriaServerMonitor serverMonitor = serverMonitor;
+	private readonly IPhoriaIslandScopedContext scopedContext = scopedContext;
+	private readonly IPhoriaIslandSsr phoriaIslandSsr = phoriaIslandSsr;
+	private readonly PhoriaOptions options = options.Value;
+
+	public async Task<PhoriaIslandHtmlContent> CreateAsync(
+		string component,
+		object? props,
+		PhoriaIslandClientDirective? client)
+	{
+		PhoriaIslandRenderMode renderMode = PhoriaIslandRenderMode.Isomorphic;
+
+		if (client == null)
+		{
+			renderMode = PhoriaIslandRenderMode.ServerOnly;
+		}
+		else if (client is PhoriaIslandClientOnlyDirective)
+		{
+			renderMode = PhoriaIslandRenderMode.ClientOnly;
+		}
+
+		if (renderMode != PhoriaIslandRenderMode.ServerOnly
+			&& serverMonitor.ServerStatus.Health != PhoriaServerHealth.Healthy)
+		{
+			// We have to render the component on the server, but the server is not healthy
+
+			throw new PhoriaIslandComponentException($"Cannot render component '{component}' on the server because the server is not healthy. Server status is '{serverMonitor.ServerStatus.Health}'.");
+		}
+
+		var island = new PhoriaIsland
+		{
+			ComponentName = component,
+			Props = props,
+			RenderMode = renderMode,
+			Client = client
+		};
+
+		scopedContext.AddIsland(island);
+
+		PhoriaIslandSsrResult? ssrResult = island.RenderMode != PhoriaIslandRenderMode.ClientOnly
+			? await phoriaIslandSsr.RenderIsland(island)
+			: null;
+
+		return new PhoriaIslandHtmlContent(
+			island,
+			ssrResult,
+			options);
+	}
+}

--- a/packages/Phoria/ServiceCollectionExtensions.cs
+++ b/packages/Phoria/ServiceCollectionExtensions.cs
@@ -71,6 +71,7 @@ public static class ServiceCollectionExtensions
 		services.TryAddScoped<PhoriaIslandEntryTagHelperMonitor>();
 		services.TryAddSingleton<IPhoriaIslandSsr, PhoriaIslandSsr>();
 		services.TryAddScoped<IPhoriaIslandScopedContext, PhoriaIslandScopedContext>();
+		services.TryAddScoped<IPhoriaIslandComponentFactory, PhoriaIslandComponentFactory>();
 
 		return services;
 	}


### PR DESCRIPTION
* The existing `PhoriaIslandTagHelper` can be used to render any Phoria Island
* However downstream projects may want to create custom Tag Helpers or View Components that encapsulate the rendering of their specific Phoria Island components to make them feel more "integrated" with their project, consistent where they are used, ease maintenance, and to add strong typing for props
* `PhoriaIslandTagHelper` can be inherited from for this purpose, but its IOC dependencies and some of the internal rendering logic would need to also be setup each time in the derived class(es), which is not something that should be the responsibility of the consumer to do and get right each time
* A `PhoriaIslandComponentFacory` will be created to encapsulate the IOC dependencies and minimise the amount of code needed to create a custom Phoria Island Tag Helper or View Component
* The `PhoriaIslandComponentFactory` can then be used internally by `PhoriaTagHelper`, and by consumers
* Docs to be updated to show intended usage